### PR TITLE
Enable storing of structured data

### DIFF
--- a/lib/logger_ets_backend.ex
+++ b/lib/logger_ets_backend.ex
@@ -14,41 +14,38 @@ defmodule LoggerEtsBackend do
     {:ok, :ok, configure(name, opts, state)}
   end
 
-  def handle_event(
-        {level, _gl, {Logger, msg, ts, md}},
-        %{level: min_level, metadata_filter: metadata_filter} = state
-      ) do
-    if (is_nil(min_level) or Logger.compare_levels(level, min_level) != :lt) and
-         metadata_matches?(md, metadata_filter) do
-      log_event(level, msg, ts, md, state)
-    end
+  def handle_event({level, _gl, {Logger, msg, ts, md}}, state) do
+    %{level: min_level, metadata_filter: md_filter} = state
+
+    if min_level_met?(level, min_level) and metadata_matches?(md, md_filter),
+      do: log_event(level, msg, ts, md, state)
 
     {:ok, state}
   end
 
-  def handle_event(:flush, state) do
-    # We're not buffering anything so this is a no-op
-    {:ok, state}
-  end
+  def handle_event(_, state), do: {:ok, state}
+  def handle_info(_, state), do: {:ok, state}
 
-  def handle_info(_, state) do
-    {:ok, state}
-  end
+  defp log_event(level, msg, ts, md, state) do
+    %{table: table, metadata: md_keys} = state
 
-  defp log_event(level, msg, ts, md, %{table: table, metadata: md_keys} = _state) do
-    try do
-      filtered_md = take_metadata(md, md_keys)
-      :ets.insert_new(table, {ts, level, msg, filtered_md})
-    rescue
-      ErlangError ->
-        # table doesn't exist or is not
-        # writable. nothing we can do
-        true
-    end
+    data =
+      case state.store_keywords do
+        true -> maybe_parse_msg(msg)
+        _ -> msg
+      end
+
+    filtered_md = take_metadata(md, md_keys)
+
+    :ets.insert_new(table, {ts, level, data, filtered_md})
+  rescue
+    ErlangError ->
+      # table doesn't exist or is not
+      # writable. nothing we can do
+      true
   end
 
   def metadata_matches?(_md, nil), do: true
-  # all of the filter keys are present
   def metadata_matches?(_md, []), do: true
 
   def metadata_matches?(md, [{key, val} | rest]) do
@@ -56,28 +53,38 @@ defmodule LoggerEtsBackend do
       {:ok, ^val} ->
         metadata_matches?(md, rest)
 
-      # fail on first mismatch
       _ ->
         false
     end
   end
 
+  def maybe_parse_msg(msg) do
+    {:ok, data} = Code.string_to_quoted(msg)
+
+    if Keyword.keyword?(data),
+      do: data,
+      else: msg
+  rescue
+    _ -> msg
+  end
+
   defp take_metadata(metadata, :all), do: metadata
 
   defp take_metadata(metadata, keys) do
-    metadatas =
-      Enum.reduce(keys, [], fn key, acc ->
-        case Keyword.fetch(metadata, key) do
-          {:ok, val} ->
-            [{key, val} | acc]
+    Enum.reduce(keys, [], fn key, acc ->
+      case Keyword.fetch(metadata, key) do
+        {:ok, val} ->
+          [{key, val} | acc]
 
-          :error ->
-            acc
-        end
-      end)
-
-    Enum.reverse(metadatas)
+        :error ->
+          acc
+      end
+    end)
+    |> Enum.reverse()
   end
+
+  defp min_level_met?(_level, nil), do: true
+  defp min_level_met?(level, min), do: Logger.compare_levels(level, min) != :lt
 
   defp configure(name, opts) do
     state = %{
@@ -87,7 +94,8 @@ defmodule LoggerEtsBackend do
       inode: nil,
       level: nil,
       metadata: nil,
-      metadata_filter: nil
+      metadata_filter: nil,
+      store_keywords: false
     }
 
     configure(name, opts, state)
@@ -96,21 +104,17 @@ defmodule LoggerEtsBackend do
   defp configure(name, opts, state) do
     env = Application.get_env(:logger, name, [])
     opts = Keyword.merge(env, opts)
-    Application.put_env(:logger, name, opts)
 
-    table = Keyword.get(opts, :table)
-    level = Keyword.get(opts, :level)
-    #
-    metadata = Keyword.get(opts, :metadata, [])
-    metadata_filter = Keyword.get(opts, :metadata_filter)
+    Application.put_env(:logger, name, opts)
 
     %{
       state
       | name: name,
-        table: table,
-        level: level,
-        metadata: metadata,
-        metadata_filter: metadata_filter
+        table: Keyword.get(opts, :table),
+        level: Keyword.get(opts, :level),
+        metadata: Keyword.get(opts, :metadata, []),
+        metadata_filter: Keyword.get(opts, :metadata_filter),
+        store_keywords: Keyword.get(opts, :store_keywords, false)
     }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule LoggerEtsBackend.MixProject do
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       description: description(),
+      aliases: aliases(),
       package: package(),
       deps: deps(),
 
@@ -43,7 +44,7 @@ defmodule LoggerEtsBackend.MixProject do
   end
 
   defp description() do
-    "A simple `Logger` backend which writes log entries to an ETS table."
+    "Logger backend that writes entries to ETS for runtime inspection."
   end
 
   defp package() do
@@ -57,5 +58,11 @@ defmodule LoggerEtsBackend.MixProject do
 
   defp docs do
     [extras: ["README.md"], main: "readme", source_ref: "v#{@version}", source_url: @github]
+  end
+
+  defp aliases do
+    [
+      test: ["test --trace --cover"]
+    ]
   end
 end

--- a/test/logger_ets_backend_test.exs
+++ b/test/logger_ets_backend_test.exs
@@ -23,7 +23,7 @@ defmodule LoggerEtsBackendTest do
     end
   end
 
-  describe "basic " do
+  describe "basic setup" do
     setup do
       config(
         table: @name,
@@ -37,7 +37,7 @@ defmodule LoggerEtsBackendTest do
       end)
     end
 
-    test "add log entry" do
+    test "can add log entry" do
       Logger.info("simple message")
       # to ensure messages are written to ets
       Logger.flush()
@@ -76,21 +76,6 @@ defmodule LoggerEtsBackendTest do
       assert ets_size() == 1
     end
 
-    test "metadata_matches?" do
-      # exact match
-      assert metadata_matches?([a: 1], a: 1) == true
-      # total mismatch
-      assert metadata_matches?([b: 1], a: 1) == false
-      # default to allow
-      assert metadata_matches?([b: 1], nil) == true
-      # metadata is superset of filter
-      assert metadata_matches?([b: 1, a: 1], a: 1) == true
-      # multiple filter keys subset of metadata
-      assert metadata_matches?([c: 1, b: 1, a: 1], b: 1, a: 1) == true
-      # multiple filter keys superset of metadata
-      assert metadata_matches?([a: 1], b: 1, a: 1) == false
-    end
-
     test "can configure metadata" do
       config(metadata: [:user_id, :auth])
 
@@ -109,7 +94,7 @@ defmodule LoggerEtsBackendTest do
       assert md |> Keyword.fetch!(:user_id) == 13
     end
 
-    test "Allow `:all` to metadata" do
+    test "allows `:all` metadata" do
       config(metadata: [])
       Logger.debug("metadata", metadata1: "foo", metadata2: "bar")
       Logger.flush()
@@ -130,6 +115,94 @@ defmodule LoggerEtsBackendTest do
       assert md[:metadata6] == "bar"
     end
   end
+
+  describe "metadata_matches?" do
+    setup do
+      config(
+        table: @name,
+        level: :debug,
+        metadata: [],
+        metadata_filter: nil
+      )
+
+      on_exit(fn ->
+        :ets.delete_all_objects(@name)
+      end)
+    end
+
+    test "can filter by metadata" do
+      # exact match
+      assert metadata_matches?([a: 1], a: 1) == true
+      # total mismatch
+      assert metadata_matches?([b: 1], a: 1) == false
+      # default to allow
+      assert metadata_matches?([b: 1], nil) == true
+      # metadata is superset of filter
+      assert metadata_matches?([b: 1, a: 1], a: 1) == true
+      # multiple filter keys subset of metadata
+      assert metadata_matches?([c: 1, b: 1, a: 1], b: 1, a: 1) == true
+      # multiple filter keys superset of metadata
+      assert metadata_matches?([a: 1], b: 1, a: 1) == false
+    end
+  end
+
+  describe "enabling `store_keywords`" do
+    setup do
+      config(
+        table: @name,
+        level: :debug,
+        metadata: [],
+        metadata_filter: nil,
+        store_keywords: true
+      )
+
+      on_exit(fn ->
+        :ets.delete_all_objects(@name)
+      end)
+    end
+
+    if Version.match?(System.version(), "~> 1.11") do
+      test "can store keyword data" do
+        data = [is_keyword: true, ordered: true]
+
+        Logger.debug(data)
+        Logger.flush()
+
+        assert {_, :debug, ^data, _} = log()
+      end
+
+      test "can store map data" do
+        data = %{is_map: true, ordered: false}
+        expected = [is_map: true, ordered: false]
+
+        Logger.debug(data)
+        Logger.flush()
+
+        assert {_, :debug, ^expected, _} = log()
+      end
+    end
+
+    test "can store string-encoded data" do
+      data = [is_keyword: true, ordered: true]
+      encoded = "#{inspect(data)}"
+
+      Logger.debug(encoded)
+      Logger.flush()
+
+      assert {_, :debug, ^data, _} = log()
+    end
+
+    test "can store a string message" do
+      data = "this is a stringy message"
+
+      Logger.debug(data)
+      Logger.flush()
+
+      assert {_, :debug, ^data, _} = log()
+    end
+  end
+
+  ## private methods
 
   defp config(opts) do
     Logger.configure_backend(@backend, opts)


### PR DESCRIPTION
This PR adds a flag, `store_keywords: <bool>`, which will attempt to store logged keyword lists & maps as keyword lists rather than as a string-encoded keyword list. For example:

```elixir
iex(1)> require Logger
Logger
iex(2)> Logger.info([screen: :dashboard, scope: :global], application: :ui)
:ok
iex(3)> :ets.lookup(:ui_log, :ets.last(:ui_log))
[
  {{{2021, 6, 18}, {6, 59, 18, 173}}, :info, [screen: :dashboard, scope: :global],
   [
     erl_level: :info,
     application: :ui,
     domain: [:elixir],
     gl: #PID<0.66.0>,
     pid: #PID<0.1138.0>,
     time: 1623992358173152
   ]}
]
```